### PR TITLE
Refactor code to use Lombok's @Slf4j for logging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,8 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.projectlombok:lombok:1.18.30'
+    annotationProcessor 'org.projectlombok:lombok:1.18.30'
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation "org.aspectj:aspectjtools:$aspectjVersion"
     implementation "org:jaudiotagger:$audioTaggerVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -44,8 +44,6 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.projectlombok:lombok:1.18.30'
-    annotationProcessor 'org.projectlombok:lombok:1.18.30'
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation "org.aspectj:aspectjtools:$aspectjVersion"
     implementation "org:jaudiotagger:$audioTaggerVersion"

--- a/src/main/java/org/jas/Launcher.java
+++ b/src/main/java/org/jas/Launcher.java
@@ -23,8 +23,10 @@ import org.jas.helper.ApplicationContextSingleton;
 import org.asmatron.messengine.engines.DefaultEngine;
 import org.springframework.context.ConfigurableApplicationContext;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+
 
 /**
  * @author josdem (joseluis.delacruz@gmail.com)
@@ -34,7 +36,6 @@ import org.slf4j.LoggerFactory;
 public class Launcher {
 	private static final String HIPECOTECH_LNF = "org.jas.laf.HipecotechLookAndFeel";
 
-  private static final Logger log = LoggerFactory.getLogger(Launcher.class);
 
 	public Launcher(ConfigurableApplicationContext applicationContext) {
 		DefaultEngine defaultEngine = applicationContext.getBean(DefaultEngine.class);

--- a/src/main/java/org/jas/aspect/AfterThrowingAdvice.java
+++ b/src/main/java/org/jas/aspect/AfterThrowingAdvice.java
@@ -22,14 +22,12 @@ import org.springframework.stereotype.Component;
 
 import org.jas.exception.BusinessException;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Aspect
 @Component
 public class AfterThrowingAdvice {
-
-  private final Logger log = LoggerFactory.getLogger(this.getClass());
 
   @AfterThrowing(pointcut = "execution(* org.jas.service..**.*(..))", throwing = "ex")
   public void doRecoveryActions(RuntimeException ex){

--- a/src/main/java/org/jas/controller/LoginController.java
+++ b/src/main/java/org/jas/controller/LoginController.java
@@ -25,13 +25,13 @@ import org.jas.event.Events;
 import org.jas.helper.LastFMAuthenticator;
 import org.jas.model.Model;
 import org.jas.model.User;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 
+@Slf4j
 @Controller
 public class LoginController {
 
@@ -40,7 +40,7 @@ public class LoginController {
     @Autowired
     private ControlEngineConfigurator configurator;
 
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
+ 
 
     @ActionMethod(Actions.LOGIN_ID)
     public void login(User user) {

--- a/src/main/java/org/jas/controller/MetadataController.java
+++ b/src/main/java/org/jas/controller/MetadataController.java
@@ -31,8 +31,6 @@ import org.jaudiotagger.audio.exceptions.CannotReadException;
 import org.jaudiotagger.audio.exceptions.InvalidAudioFrameException;
 import org.jaudiotagger.audio.exceptions.ReadOnlyFileException;
 import org.jaudiotagger.tag.TagException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 
@@ -42,8 +40,10 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
-
+import lombok.extern.slf4j.Slf4j;
 @Controller
+
+@Slf4j
 public class MetadataController {
 
     @Autowired
@@ -55,7 +55,7 @@ public class MetadataController {
 
     private List<Metadata> metadataList;
 
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
+
 
     @ActionMethod(Actions.GET_METADATA)
     public void getMetadata() {

--- a/src/main/java/org/jas/controller/ScrobblerController.java
+++ b/src/main/java/org/jas/controller/ScrobblerController.java
@@ -22,14 +22,14 @@ import org.jas.action.ActionResult;
 import org.jas.action.Actions;
 import org.jas.helper.ScrobblerHelper;
 import org.jas.model.Metadata;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.PostConstruct;
 import java.io.IOException;
 
+@Slf4j
 @Controller
 public class ScrobblerController {
 
@@ -38,7 +38,7 @@ public class ScrobblerController {
     @Autowired
     private ControlEngineConfigurator configurator;
 
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
+
 
     @PostConstruct
     public void setup() {

--- a/src/main/java/org/jas/dnd/DnDListenerCollection.java
+++ b/src/main/java/org/jas/dnd/DnDListenerCollection.java
@@ -22,12 +22,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 
 public class DnDListenerCollection<T extends DragAndDropListener> {
 	private Map<Component, List<T>> listeners = new HashMap<Component, List<T>>();
-  private static final Logger log = LoggerFactory.getLogger(DnDListenerCollection.class);
+
 
 	public void put(Component component, T listener) {
 		List<T> listeners = null;

--- a/src/main/java/org/jas/dnd/DragAndDropIterators.java
+++ b/src/main/java/org/jas/dnd/DragAndDropIterators.java
@@ -23,11 +23,12 @@ import java.util.Arrays;
 
 import javax.swing.SwingUtilities;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
+
+
+@Slf4j
 
 public class DragAndDropIterators {
-  private static final Logger log = LoggerFactory.getLogger(DragAndDropIterators.class);
 
 	public static DoInListeners<Void, DragOverListener> dragEnter(Point point, DraggedObject draggedObject, boolean validationResult,
 			Container currentFrame) {

--- a/src/main/java/org/jas/dnd/DragTooltipDialog.java
+++ b/src/main/java/org/jas/dnd/DragTooltipDialog.java
@@ -39,13 +39,14 @@ import javax.swing.JPanel;
 import org.jas.util.Picture;
 import org.jas.util.FileSystemValidatorLight;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 
 public class DragTooltipDialog extends JDialog {
 	private static final String DRAG_DIALOG_NAME = "dragDialog";
 
-  private Logger log = LoggerFactory.getLogger(this.getClass());
+
 
 	private static final Rectangle DRAG_ICON_BOUNDS = new Rectangle(1, 1, 18, 18);
 	private static final int DEFAULT_MIN_FONT_WIDTH = 4;

--- a/src/main/java/org/jas/dnd/DraggedObjectPictureGenerator.java
+++ b/src/main/java/org/jas/dnd/DraggedObjectPictureGenerator.java
@@ -23,12 +23,12 @@ import java.awt.datatransfer.Transferable;
 
 import org.jas.util.Picture;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 
 public class DraggedObjectPictureGenerator extends DraggedObjectFileSystemGenerator {
 
-  private static final Logger log = LoggerFactory.getLogger(DraggedObjectPictureGenerator.class);
 
 	@Override
 	public DraggedObject get(Transferable transferable) {

--- a/src/main/java/org/jas/dnd/FileDragSource.java
+++ b/src/main/java/org/jas/dnd/FileDragSource.java
@@ -219,15 +219,15 @@ import java.awt.dnd.InvalidDnDOperationException;
 import java.io.File;
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 
 public final class FileDragSource implements DragGestureListener, DragSourceListener {
 
   private DragSource dragSource;
 	private FileSelection fileSelection;
 
-  private Logger log = LoggerFactory.getLogger(this.getClass());
 
 	public static void addDragSource(Component c, FileSelection modelSelection) {
 		DragSource dragSource = new DragSource();

--- a/src/main/java/org/jas/dnd/ImageDropListener.java
+++ b/src/main/java/org/jas/dnd/ImageDropListener.java
@@ -26,15 +26,15 @@ import org.jas.observer.ObserverCollection;
 import org.jas.util.Picture;
 import org.jas.util.FileSystemValidatorLight;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 
 public class ImageDropListener implements DropListener {
   private final ImagePanel imagePanel;
 	private static final Class<?>[] classes = new Class<?>[] { Picture.class };
 	private final Observable<ObservValue<ImagePanel>> nombre = new Observable<ObservValue<ImagePanel>>();
 
-  private Logger log = LoggerFactory.getLogger(this.getClass());
 
 	@Override
 	public Class<?>[] handledTypes() {

--- a/src/main/java/org/jas/dnd/Jdk6u10TransparencyManager.java
+++ b/src/main/java/org/jas/dnd/Jdk6u10TransparencyManager.java
@@ -27,8 +27,9 @@ import java.awt.GraphicsEnvironment;
 import javax.swing.JComponent;
 import org.jas.util.MethodWrapper;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 
 public class Jdk6u10TransparencyManager implements TransparencyManager {
 
@@ -38,7 +39,6 @@ public class Jdk6u10TransparencyManager implements TransparencyManager {
 	private MethodWrapper<Boolean> isTranslucencyCapableMethod;
   private MethodWrapper<Boolean> isTranslucencySupportedMethod;
 
-  private static final Logger log = LoggerFactory.getLogger(Jdk6u10TransparencyManager.class);
 
 	public Jdk6u10TransparencyManager() {
 		Class<?> translucencyClass = MethodWrapper.getClass("com.sun.awt.AWTUtilities$Translucency");

--- a/src/main/java/org/jas/dnd/MultiLayerDropTargetListener.java
+++ b/src/main/java/org/jas/dnd/MultiLayerDropTargetListener.java
@@ -30,8 +30,9 @@ import org.jas.observer.Observer;
 import org.jas.observer.ObservValue;
 import org.springframework.stereotype.Service;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 
 @Service
 public class MultiLayerDropTargetListener extends DropTargetAdapter implements Observer<ObservValue<Component>> {
@@ -47,7 +48,6 @@ public class MultiLayerDropTargetListener extends DropTargetAdapter implements O
 
 	private DragAndDropAction currentAction;
 
-  private Logger log = LoggerFactory.getLogger(this.getClass());
 
 	public MultiLayerDropTargetListener() {
 		this.draggedObjectFactory = new DraggedObjectFactory();

--- a/src/main/java/org/jas/dnd/TransparencyManagerFactory.java
+++ b/src/main/java/org/jas/dnd/TransparencyManagerFactory.java
@@ -16,13 +16,13 @@
 
 package org.jas.dnd;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 
 public class TransparencyManagerFactory {
 	private static TransparencyManager manager;
 
-  private static final Logger log = LoggerFactory.getLogger(TransparencyManagerFactory.class);
 
 	public static TransparencyManager getManager() {
 		if (manager != null) {

--- a/src/main/java/org/jas/gui/ImagePanel.java
+++ b/src/main/java/org/jas/gui/ImagePanel.java
@@ -28,8 +28,9 @@ import java.awt.image.BufferedImage;
 
 import javax.swing.JPanel;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 
 public final class ImagePanel extends JPanel {
 
@@ -39,7 +40,6 @@ public final class ImagePanel extends JPanel {
 	private double arcHeight;
 	private double arcWidth;
 
-  private Logger log = LoggerFactory.getLogger(this.getClass());
 
 	public ImagePanel() {
 	}

--- a/src/main/java/org/jas/gui/MainWindow.java
+++ b/src/main/java/org/jas/gui/MainWindow.java
@@ -95,8 +95,9 @@ import org.jas.observer.ObservValue;
 import org.jas.observer.Observer;
 import org.jas.util.ImageUtils;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 
 /**
  * @understands A principal JAudioScrobbler principal window
@@ -203,7 +204,6 @@ public class MainWindow extends JFrame {
 	@Autowired
 	private ControlEngineConfigurator controlEngineConfigurator;
 
-  private Logger log = LoggerFactory.getLogger(this.getClass());
 
 	public MainWindow() {
 		super(ApplicationState.APPLICATION_NAME);

--- a/src/main/java/org/jas/helper/LastFMAlbumHelper.java
+++ b/src/main/java/org/jas/helper/LastFMAlbumHelper.java
@@ -28,8 +28,9 @@ import de.umass.lastfm.Album;
 import org.jas.Auth;
 import org.jas.model.GenreTypes;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 
 /**
  * @understands A class who gets album information from LastFM
@@ -37,7 +38,6 @@ import org.slf4j.LoggerFactory;
 
 @Component
 public class LastFMAlbumHelper {
-  private Logger log = LoggerFactory.getLogger(this.getClass());
 
 	public Album getAlbum(String artist, String album) {
 		return Album.getInfo(artist, album, Auth.KEY);

--- a/src/main/java/org/jas/helper/MetadataExporter.java
+++ b/src/main/java/org/jas/helper/MetadataExporter.java
@@ -38,8 +38,9 @@ import org.jas.service.MetadataService;
 import org.jas.service.FormatterService;
 import org.jas.exception.MetadataException;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 
 @Service
 public class MetadataExporter {
@@ -57,7 +58,6 @@ public class MetadataExporter {
 	@Autowired
 	private FormatterService formatter;
 
-  private Logger log = LoggerFactory.getLogger(this.getClass());
 
 	public void export(ExportPackage exportPackage) throws IOException, CannotReadException, TagException, ReadOnlyFileException, MetadataException {
 		File file = fileUtils.createFile(exportPackage.getRoot(), StringUtils.EMPTY, ApplicationState.FILE_EXT);

--- a/src/main/java/org/jas/helper/ScrobblerHelper.java
+++ b/src/main/java/org/jas/helper/ScrobblerHelper.java
@@ -39,8 +39,9 @@ import org.jas.model.Model;
 import org.jas.model.Metadata;
 import org.jas.action.ActionResult;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 
 /**
 * @understands A class who knows how to send scrobblings
@@ -57,7 +58,6 @@ public class ScrobblerHelper {
 	private static final int DELTA = 120;
 
 	private ControlEngine controlEngine;
-  private Logger log = LoggerFactory.getLogger(this.getClass());
 
 	private ActionResult scrobbling(Metadata metadata) throws IOException, InterruptedException {
 		User currentUser = controlEngine.get(Model.CURRENT_USER);

--- a/src/main/java/org/jas/metadata/MetadataReader.java
+++ b/src/main/java/org/jas/metadata/MetadataReader.java
@@ -40,8 +40,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.jas.event.Events;
 import org.jas.model.Metadata;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 
 /**
 * @undestands A class who gather all common methods getting Metadata
@@ -57,7 +58,6 @@ public abstract class MetadataReader {
 	@Autowired
 	protected ControlEngineConfigurator configurator;
 
-  protected Logger log = LoggerFactory.getLogger(this.getClass());
 
 	public abstract String getGenre();
 	public abstract Metadata getMetadata(File file) throws CannotReadException, IOException, TagException, ReadOnlyFileException, InvalidAudioFrameException, MetadataException;

--- a/src/main/java/org/jas/metadata/MetadataWriter.java
+++ b/src/main/java/org/jas/metadata/MetadataWriter.java
@@ -40,8 +40,9 @@ import org.jas.util.ImageUtils;
 import org.jas.helper.ArtworkHelper;
 import org.jas.helper.AudioFileHelper;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 
 /**
 * @understands A class who knows how to write metadata in a audio file
@@ -54,7 +55,6 @@ public class MetadataWriter {
 	private ImageUtils imageUtils = new ImageUtils();
 	private ArtworkHelper artworkHelper = new ArtworkHelper();
 
-  private Logger log = LoggerFactory.getLogger(this.getClass());
 
 	public void setFile(File file) {
 		try {

--- a/src/main/java/org/jas/observer/Observable.java
+++ b/src/main/java/org/jas/observer/Observable.java
@@ -19,13 +19,14 @@ package org.jas.observer;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+
 
 public class Observable<T extends ObserveObject> implements ObserverCollection<T> {
 	private List<Observer<T>> observers = new ArrayList<Observer<T>>();
 
-  private Logger log = LoggerFactory.getLogger(this.getClass());
 
 	public boolean fire(T param) {
 		if (param == null) {

--- a/src/main/java/org/jas/service/impl/ExtractServiceImpl.java
+++ b/src/main/java/org/jas/service/impl/ExtractServiceImpl.java
@@ -18,18 +18,19 @@ package org.jas.service.impl;
 
 import org.jas.model.Metadata;
 import org.jas.service.ExtractService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.io.File;
 import java.util.NoSuchElementException;
 import java.util.StringTokenizer;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+
 
 @Service
 public class ExtractServiceImpl implements ExtractService {
 
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
 
     public Metadata extractFromFileName(File file) {
         String titleComplete = file.getName();

--- a/src/main/java/org/jas/service/impl/LastFMCompleteServiceImpl.java
+++ b/src/main/java/org/jas/service/impl/LastFMCompleteServiceImpl.java
@@ -39,8 +39,10 @@ import org.jas.helper.LastFMAlbumHelper;
 import org.jas.service.ImageService;
 import org.jas.service.LastFMCompleteService;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+
 
 /**
  * @understands A class who evaluates metadata and decides if LastFM can help to complete information
@@ -56,7 +58,6 @@ public class LastFMCompleteServiceImpl implements LastFMCompleteService {
 
   private HashMap<String, Album> cachedAlbums = new HashMap<String, Album>();
 
-  private Logger log = LoggerFactory.getLogger(this.getClass());
 
 	public boolean canLastFMHelpToComplete(Metadata metadata) {
 		String artist = metadata.getArtist();

--- a/src/main/java/org/jas/service/impl/LastfmServiceImpl.java
+++ b/src/main/java/org/jas/service/impl/LastfmServiceImpl.java
@@ -28,8 +28,10 @@ import org.jas.action.ActionResult;
 import org.jas.service.LastfmService;
 import org.jas.service.LastFMCompleteService;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+
 
 /**
  * @understands A class who completes metadata using LastFM service
@@ -41,7 +43,6 @@ public class LastfmServiceImpl implements LastfmService {
 	@Autowired
 	private LastFMCompleteService completeService;
 
-  private Logger log = LoggerFactory.getLogger(this.getClass());
 
 	public synchronized ActionResult completeLastFM(Metadata metadata) {
 		try {

--- a/src/main/java/org/jas/service/impl/MetadataServiceImpl.java
+++ b/src/main/java/org/jas/service/impl/MetadataServiceImpl.java
@@ -31,8 +31,6 @@ import org.jaudiotagger.audio.exceptions.CannotReadException;
 import org.jaudiotagger.audio.exceptions.InvalidAudioFrameException;
 import org.jaudiotagger.audio.exceptions.ReadOnlyFileException;
 import org.jaudiotagger.tag.TagException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -43,6 +41,10 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+
 
 @Service
 public class MetadataServiceImpl implements MetadataService {
@@ -64,7 +66,6 @@ public class MetadataServiceImpl implements MetadataService {
 
     private List<Metadata> metadataList;
     private Set<File> filesWithoutMinimumMetadata;
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
 
     public List<Metadata> extractMetadata(File root) throws IOException, TooMuchFilesException, CannotReadException, TagException, ReadOnlyFileException, InvalidAudioFrameException, MetadataException {
         metadataList = new ArrayList<>();

--- a/src/main/java/org/jas/util/ImageUtils.java
+++ b/src/main/java/org/jas/util/ImageUtils.java
@@ -19,14 +19,15 @@ package org.jas.util;
 import org.jas.ApplicationState;
 import org.jas.service.ImageService;
 import org.jas.service.impl.ImageServiceImpl;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.awt.image.ImageObserver;
 import java.io.File;
 import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 
 public class ImageUtils {
     private ImageService imageService = new ImageServiceImpl();
@@ -34,7 +35,6 @@ public class ImageUtils {
     private FileUtils fileUtils = new FileUtils();
     private static final int THREE_HUNDRED = 300;
 
-    private Logger log = LoggerFactory.getLogger(this.getClass());
 
     public Image resize(Image image, int width, int height) {
         BufferedImage bufferedImage = (BufferedImage) image;

--- a/src/main/java/org/jas/util/MethodWrapper.java
+++ b/src/main/java/org/jas/util/MethodWrapper.java
@@ -18,14 +18,15 @@ package org.jas.util;
 
 import java.lang.reflect.Method;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+
 
 public class MethodWrapper<T> {
 	private final Method method;
 	private final Class<?> returnType;
 
-  private static final Logger log = LoggerFactory.getLogger(MethodWrapper.class);
 
 	public static MethodWrapperBuilderPhase1 forClass(String className) {
 		return new MethodWrapperBuilder(className);

--- a/src/test/java/org/jas/collaborator/TestJAudioTaggerCollaborator.java
+++ b/src/test/java/org/jas/collaborator/TestJAudioTaggerCollaborator.java
@@ -25,18 +25,19 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class TestJAudioTaggerCollaborator {
 
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
 
     @InjectMocks
     private final JAudioTaggerCollaborator jAudioTaggerCollaborator = new JAudioTaggerCollaborator();

--- a/src/test/java/org/jas/controller/TestDefaultController.java
+++ b/src/test/java/org/jas/controller/TestDefaultController.java
@@ -26,8 +26,6 @@ import org.junit.jupiter.api.TestInfo;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,6 +33,10 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+
 
 class TestDefaultController {
 
@@ -46,7 +48,6 @@ class TestDefaultController {
 
     private final List<Metadata> metadatas = new ArrayList<Metadata>();
 
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
 
     @BeforeEach
     public void setup() throws Exception {

--- a/src/test/java/org/jas/controller/TestExporterController.java
+++ b/src/test/java/org/jas/controller/TestExporterController.java
@@ -26,14 +26,16 @@ import org.junit.jupiter.api.TestInfo;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+
 
 class TestExporterController {
 
@@ -45,7 +47,6 @@ class TestExporterController {
     @Mock
     private ExporterHelper exporterHelper;
 
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
 
     @BeforeEach
     public void setup() throws Exception {

--- a/src/test/java/org/jas/controller/TestLoginController.java
+++ b/src/test/java/org/jas/controller/TestLoginController.java
@@ -31,8 +31,6 @@ import org.junit.jupiter.api.TestInfo;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
@@ -41,6 +39,9 @@ import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 
 class TestLoginController {
 
@@ -61,7 +62,6 @@ class TestLoginController {
 
     private User credentials;
 
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
 
     @BeforeEach
     public void setup() throws Exception {

--- a/src/test/java/org/jas/controller/TestScrobblerController.java
+++ b/src/test/java/org/jas/controller/TestScrobblerController.java
@@ -28,14 +28,16 @@ import org.junit.jupiter.api.TestInfo;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+
 
 class TestScrobblerController {
 
@@ -51,7 +53,6 @@ class TestScrobblerController {
     @Mock
     private ScrobblerHelper scrobblerHelper;
 
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
 
     @BeforeEach
     public void setup() throws Exception {

--- a/src/test/java/org/jas/helper/TestImageHelper.java
+++ b/src/test/java/org/jas/helper/TestImageHelper.java
@@ -23,18 +23,20 @@ import org.jas.service.impl.ImageServiceImpl;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
 
 import java.io.File;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+
 
 class TestImageHelper {
 
     private final ImageService imageService = new ImageServiceImpl();
 
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
 
     @Test
     @DisplayName("creating a temp file for cover art")

--- a/src/test/java/org/jas/service/TestExtractService.java
+++ b/src/test/java/org/jas/service/TestExtractService.java
@@ -25,13 +25,16 @@ import org.junit.jupiter.api.TestInfo;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
 
 import java.io.File;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+
 
 class TestExtractService {
 
@@ -42,8 +45,6 @@ class TestExtractService {
 
     @Mock
     private File file;
-
-    private Logger log = LoggerFactory.getLogger(this.getClass());
 
     @BeforeEach
     public void setup() throws Exception {

--- a/src/test/java/org/jas/service/TestFormatterService.java
+++ b/src/test/java/org/jas/service/TestFormatterService.java
@@ -24,13 +24,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+
 
 public class TestFormatterService {
     private final FormatterService formatter = new FormatterServiceImpl();
@@ -55,8 +57,6 @@ public class TestFormatterService {
     private final String expectedAlbum = "Vision";
 
     private final Metadata metadata = new Metadata();
-
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
 
     @BeforeEach
     public void setup() throws Exception {

--- a/src/test/java/org/jas/service/TestMetadataService.java
+++ b/src/test/java/org/jas/service/TestMetadataService.java
@@ -38,8 +38,6 @@ import org.junit.jupiter.api.TestInfo;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -55,6 +53,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+
 
 class TestMetadataService {
 
@@ -101,7 +103,6 @@ class TestMetadataService {
     private static final String MY_REMIXES = "My Remixes";
     private static final String ARTIST = "Raul Islas";
 
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
 
     @BeforeEach
     public void setup() throws Exception {

--- a/src/test/java/org/jas/util/TestImageUtils.java
+++ b/src/test/java/org/jas/util/TestImageUtils.java
@@ -26,8 +26,6 @@ import org.junit.jupiter.api.TestInfo;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.awt.*;
 import java.awt.image.ImageObserver;
@@ -37,6 +35,10 @@ import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+
 
 public class TestImageUtils {
 
@@ -56,7 +58,6 @@ public class TestImageUtils {
     @Mock
     private File root;
 
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
 
     @BeforeEach
     public void setup() throws Exception {


### PR DESCRIPTION
 This pull request refactors the code to replace manual logger initialization using LoggerFactory with Lombok's @Slf4j annotation and removed the manual Logger initialization (private static final Logger log = LoggerFactory.getLogger(LoginController.class);). #37 



cc.
@josdem 