### PR TITLE
Implement CompleteService and adapters for MusicBrainz and LastFM

### DIFF
--- a/src/main/java/com/josdem/jmetadata/model/AlbumInfo.java
+++ b/src/main/java/com/josdem/jmetadata/model/AlbumInfo.java
@@ -1,0 +1,27 @@
+/*
+   Copyright 2025 Jose Morales contact@josdem.io
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.josdem.jmetadata.model;
+
+import java.awt.Image;
+import lombok.Data;
+
+@Data
+public class AlbumInfo {
+  private String year;
+  private Image coverArt;
+  private String genre;
+}

--- a/src/main/java/com/josdem/jmetadata/service/CompleteService.java
+++ b/src/main/java/com/josdem/jmetadata/service/CompleteService.java
@@ -1,0 +1,35 @@
+/*
+   Copyright 2025 Jose Morales contact@josdem.io
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.josdem.jmetadata.service;
+
+import com.josdem.jmetadata.action.ActionResult;
+import com.josdem.jmetadata.model.AlbumInfo;
+import com.josdem.jmetadata.model.Metadata;
+
+public interface CompleteService {
+  /** Determines if the metadata can be completed. */
+  boolean canComplete(Metadata metadata);
+
+  /** Retrieves album information based on the given metadata. */
+  AlbumInfo getInfo(Metadata metadata);
+
+  /**
+   * Compares the retrieved album information with the current metadata to determine if there is new
+   * data.
+   */
+  ActionResult isSomethingNew(AlbumInfo albumInfo, Metadata metadata);
+}

--- a/src/main/java/com/josdem/jmetadata/service/impl/LastFMCompleteServiceAdapter.java
+++ b/src/main/java/com/josdem/jmetadata/service/impl/LastFMCompleteServiceAdapter.java
@@ -29,37 +29,37 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class LastFMCompleteServiceAdapter implements CompleteService {
 
-  private final LastFMCompleteService lastFMCompleteService;
+    private final LastFMCompleteService lastFMCompleteService;
 
-  @Override
-  public boolean canComplete(Metadata metadata) {
-    return lastFMCompleteService.canLastFMHelpToComplete(metadata);
-  }
-
-  @Override
-  public AlbumInfo getInfo(Metadata metadata) {
-    try {
-      LastfmAlbum lastfmAlbum = lastFMCompleteService.getLastFM(metadata);
-      if (lastfmAlbum == null) {
-        return null;
-      }
-      AlbumInfo albumInfo = new AlbumInfo();
-      albumInfo.setYear(lastfmAlbum.getYear());
-      albumInfo.setCoverArt(lastfmAlbum.getImageIcon());
-      albumInfo.setGenre(lastfmAlbum.getGenre());
-      return albumInfo;
-    } catch (Exception e) {
-      log.error("Error retrieving LastFM information: {}", e.getMessage(), e);
-      return null;
+    @Override
+    public boolean canComplete(Metadata metadata) {
+        return lastFMCompleteService.canLastFMHelpToComplete(metadata);
     }
-  }
 
-  @Override
-  public ActionResult isSomethingNew(AlbumInfo albumInfo, Metadata metadata) {
-    LastfmAlbum lastfmAlbum = new LastfmAlbum();
-    lastfmAlbum.setYear(albumInfo.getYear());
-    lastfmAlbum.setGenre(albumInfo.getGenre());
-    lastfmAlbum.setImageIcon(albumInfo.getCoverArt());
-    return lastFMCompleteService.isSomethingNew(lastfmAlbum, metadata);
-  }
+    @Override
+    public AlbumInfo getInfo(Metadata metadata) {
+        try {
+            var lastfmAlbum = lastFMCompleteService.getLastFM(metadata);
+            if (lastfmAlbum == null) {
+                return null;
+            }
+            var albumInfo = new AlbumInfo();
+            albumInfo.setYear(lastfmAlbum.getYear());
+            albumInfo.setCoverArt(lastfmAlbum.getImageIcon());
+            albumInfo.setGenre(lastfmAlbum.getGenre());
+            return albumInfo;
+        } catch (Exception e) {
+            log.error("Error retrieving LastFM information: {}", e.getMessage(), e);
+            return null;
+        }
+    }
+
+    @Override
+    public ActionResult isSomethingNew(AlbumInfo albumInfo, Metadata metadata) {
+        var lastfmAlbum = new LastfmAlbum();
+        lastfmAlbum.setYear(albumInfo.getYear());
+        lastfmAlbum.setGenre(albumInfo.getGenre());
+        lastfmAlbum.setImageIcon(albumInfo.getCoverArt());
+        return lastFMCompleteService.isSomethingNew(lastfmAlbum, metadata);
+    }
 }

--- a/src/main/java/com/josdem/jmetadata/service/impl/LastFMCompleteServiceAdapter.java
+++ b/src/main/java/com/josdem/jmetadata/service/impl/LastFMCompleteServiceAdapter.java
@@ -1,0 +1,65 @@
+/*
+   Copyright 2025 Jose Morales contact@josdem.io
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.josdem.jmetadata.service.impl;
+
+import com.josdem.jmetadata.action.ActionResult;
+import com.josdem.jmetadata.model.AlbumInfo;
+import com.josdem.jmetadata.model.LastfmAlbum;
+import com.josdem.jmetadata.model.Metadata;
+import com.josdem.jmetadata.service.CompleteService;
+import com.josdem.jmetadata.service.LastFMCompleteService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class LastFMCompleteServiceAdapter implements CompleteService {
+
+  private final LastFMCompleteService lastFMCompleteService;
+
+  @Override
+  public boolean canComplete(Metadata metadata) {
+    return lastFMCompleteService.canLastFMHelpToComplete(metadata);
+  }
+
+  @Override
+  public AlbumInfo getInfo(Metadata metadata) {
+    try {
+      LastfmAlbum lastfmAlbum = lastFMCompleteService.getLastFM(metadata);
+      if (lastfmAlbum == null) {
+        return null;
+      }
+      AlbumInfo albumInfo = new AlbumInfo();
+      albumInfo.setYear(lastfmAlbum.getYear());
+      albumInfo.setCoverArt(lastfmAlbum.getImageIcon());
+      albumInfo.setGenre(lastfmAlbum.getGenre());
+      return albumInfo;
+    } catch (Exception e) {
+      log.error("Error retrieving LastFM information: {}", e.getMessage(), e);
+      return null;
+    }
+  }
+
+  @Override
+  public ActionResult isSomethingNew(AlbumInfo albumInfo, Metadata metadata) {
+    LastfmAlbum lastfmAlbum = new LastfmAlbum();
+    lastfmAlbum.setYear(albumInfo.getYear());
+    lastfmAlbum.setGenre(albumInfo.getGenre());
+    lastfmAlbum.setImageIcon(albumInfo.getCoverArt());
+    return lastFMCompleteService.isSomethingNew(lastfmAlbum, metadata);
+  }
+}

--- a/src/main/java/com/josdem/jmetadata/service/impl/MusicBrainzCompleteServiceAdapter.java
+++ b/src/main/java/com/josdem/jmetadata/service/impl/MusicBrainzCompleteServiceAdapter.java
@@ -1,0 +1,48 @@
+package com.josdem.jmetadata.service.impl;
+
+import com.josdem.jmetadata.action.ActionResult;
+import com.josdem.jmetadata.model.Album;
+import com.josdem.jmetadata.model.AlbumInfo;
+import com.josdem.jmetadata.model.Metadata;
+import com.josdem.jmetadata.service.CompleteService;
+import com.josdem.jmetadata.service.MusicBrainzService;
+import com.josdem.jmetadata.util.AlbumUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class MusicBrainzCompleteServiceAdapter implements CompleteService {
+
+  private final MusicBrainzService musicBrainzService;
+
+  @Override
+  public boolean canComplete(Metadata metadata) {
+    return metadata.getAlbum() != null && !metadata.getAlbum().trim().isEmpty();
+  }
+
+  @Override
+  public AlbumInfo getInfo(Metadata metadata) {
+    Album album = musicBrainzService.getAlbumByName(metadata.getAlbum());
+    if (album == null) {
+      return null;
+    }
+    AlbumInfo albumInfo = new AlbumInfo();
+    albumInfo.setYear(AlbumUtils.formatYear(album.getDate()));
+    // Optionally, set coverArt and genre if available.
+    return albumInfo;
+  }
+
+  @Override
+  public ActionResult isSomethingNew(AlbumInfo albumInfo, Metadata metadata) {
+    boolean updated = false;
+    if (albumInfo != null) {
+      if (metadata.getYear() == null || metadata.getYear().isEmpty()) {
+        metadata.setYear(albumInfo.getYear());
+        updated = true;
+      }
+      // Additional logic for coverArt and genre can be added here.
+    }
+    return updated ? ActionResult.New : ActionResult.Ready;
+  }
+}

--- a/src/main/java/com/josdem/jmetadata/service/impl/MusicBrainzCompleteServiceAdapter.java
+++ b/src/main/java/com/josdem/jmetadata/service/impl/MusicBrainzCompleteServiceAdapter.java
@@ -1,7 +1,22 @@
+/*
+   Copyright 2025 Jose Morales contact@josdem.io
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package com.josdem.jmetadata.service.impl;
 
 import com.josdem.jmetadata.action.ActionResult;
-import com.josdem.jmetadata.model.Album;
 import com.josdem.jmetadata.model.AlbumInfo;
 import com.josdem.jmetadata.model.Metadata;
 import com.josdem.jmetadata.service.CompleteService;
@@ -14,35 +29,32 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class MusicBrainzCompleteServiceAdapter implements CompleteService {
 
-  private final MusicBrainzService musicBrainzService;
+    private final MusicBrainzService musicBrainzService;
 
-  @Override
-  public boolean canComplete(Metadata metadata) {
-    return metadata.getAlbum() != null && !metadata.getAlbum().trim().isEmpty();
-  }
-
-  @Override
-  public AlbumInfo getInfo(Metadata metadata) {
-    Album album = musicBrainzService.getAlbumByName(metadata.getAlbum());
-    if (album == null) {
-      return null;
+    @Override
+    public boolean canComplete(Metadata metadata) {
+        return metadata.getAlbum() != null && !metadata.getAlbum().trim().isEmpty();
     }
-    AlbumInfo albumInfo = new AlbumInfo();
-    albumInfo.setYear(AlbumUtils.formatYear(album.getDate()));
-    // Optionally, set coverArt and genre if available.
-    return albumInfo;
-  }
 
-  @Override
-  public ActionResult isSomethingNew(AlbumInfo albumInfo, Metadata metadata) {
-    boolean updated = false;
-    if (albumInfo != null) {
-      if (metadata.getYear() == null || metadata.getYear().isEmpty()) {
-        metadata.setYear(albumInfo.getYear());
-        updated = true;
-      }
-      // Additional logic for coverArt and genre can be added here.
+    @Override
+    public AlbumInfo getInfo(Metadata metadata) {
+        var album = musicBrainzService.getAlbumByName(metadata.getAlbum());
+        if (album == null) {
+            return null;
+        }
+        var albumInfo = new AlbumInfo();
+        albumInfo.setYear(AlbumUtils.formatYear(album.getDate()));
+        // Optionally, set coverArt and genre if available.
+        return albumInfo;
     }
-    return updated ? ActionResult.New : ActionResult.Ready;
-  }
+
+    @Override
+    public ActionResult isSomethingNew(AlbumInfo albumInfo, Metadata metadata) {
+        boolean updated = false;
+        if (albumInfo != null && (metadata.getYear() == null || metadata.getYear().isEmpty())) {
+            metadata.setYear(albumInfo.getYear());
+            updated = true;
+        }
+        return updated ? ActionResult.New : ActionResult.Ready;
+    }
 }


### PR DESCRIPTION
I have implemented the new CompleteService interface along with two adapters:

LastFMCompleteServiceAdapter: Adapts the existing logic from LastFMCompleteService.
MusicBrainzCompleteServiceAdapter: Encapsulates the logic from MusicBrainzService.
Additionally, I created the AlbumInfo model as a common container for album data (such as year, cover art, and genre).

All tests pass.

I’m open to feedback or adjustments. Thank you very much!