### PR TITLE
Add tests for AlbumUtils private constructor and formatYear method

### DIFF
--- a/src/main/java/com/josdem/jmetadata/util/AlbumUtils.java
+++ b/src/main/java/com/josdem/jmetadata/util/AlbumUtils.java
@@ -16,13 +16,17 @@
 
 package com.josdem.jmetadata.util;
 
+import com.josdem.jmetadata.exception.BusinessException;
+
 public class AlbumUtils {
 
   private AlbumUtils() {
     throw new IllegalStateException("Utility class");
   }
-
   public static String formatYear(String date) {
+    if (date == null || date.length() < 4 || !date.matches("\\d{4}-\\d{2}-\\d{2}")) {
+      throw new BusinessException("Invalid date");
+    }
     return date.substring(0, 4);
   }
 }

--- a/src/test/java/com/josdem/jmetadata/util/AlbumUtilsTest.java
+++ b/src/test/java/com/josdem/jmetadata/util/AlbumUtilsTest.java
@@ -1,0 +1,64 @@
+package com.josdem.jmetadata.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+@Slf4j
+public class AlbumUtilsTest {
+
+  @Test
+  @DisplayName("formatting year from date")
+  public void testFormatYear(TestInfo testInfo) {
+    log.info(testInfo.getDisplayName());
+
+    // Arrange
+    String date = "2025-02-03";
+
+    // Act
+    String year = AlbumUtils.formatYear(date);
+
+    // Assert
+    assertEquals("2025", year);
+  }
+
+  @Test
+  @DisplayName("formatting year with invalid date")
+  public void testFormatYearWithInvalidDate(TestInfo testInfo) {
+    log.info(testInfo.getDisplayName());
+
+    // Arrange
+    String date = "20";
+
+    // Act & Assert
+    assertThrows(
+        StringIndexOutOfBoundsException.class,
+        () -> {
+          AlbumUtils.formatYear(date);
+        });
+  }
+
+  @Test
+  @DisplayName("testing private constructor")
+  public void testPrivateConstructor(TestInfo testInfo) {
+    log.info(testInfo.getDisplayName());
+
+    // Act & Assert
+    assertThrows(
+        IllegalStateException.class,
+        () -> {
+          java.lang.reflect.Constructor<AlbumUtils> constructor =
+              AlbumUtils.class.getDeclaredConstructor();
+          constructor.setAccessible(true);
+          try {
+            constructor.newInstance();
+          } catch (java.lang.reflect.InvocationTargetException e) {
+            throw (IllegalStateException) e.getCause();
+          }
+        });
+  }
+}

--- a/src/test/java/com/josdem/jmetadata/util/AlbumUtilsTest.java
+++ b/src/test/java/com/josdem/jmetadata/util/AlbumUtilsTest.java
@@ -7,13 +7,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import com.josdem.jmetadata.exception.BusinessException;
 
 @Slf4j
-public class AlbumUtilsTest {
+class AlbumUtilsTest {
 
   @Test
   @DisplayName("formatting year from date")
-  public void testFormatYear(TestInfo testInfo) {
+  void testFormatYear(TestInfo testInfo) {
     log.info(testInfo.getDisplayName());
 
     // Arrange
@@ -28,37 +29,25 @@ public class AlbumUtilsTest {
 
   @Test
   @DisplayName("formatting year with invalid date")
-  public void testFormatYearWithInvalidDate(TestInfo testInfo) {
+  void testFormatYearWithInvalidDate(TestInfo testInfo) {
     log.info(testInfo.getDisplayName());
 
     // Arrange
     String date = "20";
 
     // Act & Assert
-    assertThrows(
-        StringIndexOutOfBoundsException.class,
-        () -> {
-          AlbumUtils.formatYear(date);
-        });
+    assertThrows(BusinessException.class, () -> AlbumUtils.formatYear(date));
   }
 
   @Test
-  @DisplayName("testing private constructor")
-  public void testPrivateConstructor(TestInfo testInfo) {
+  @DisplayName("formatting year with non-date string")
+  void testFormatYearWithNonDateString(TestInfo testInfo) {
     log.info(testInfo.getDisplayName());
 
+    // Arrange
+    String date = "thisIsNotValidDate";
+
     // Act & Assert
-    assertThrows(
-        IllegalStateException.class,
-        () -> {
-          java.lang.reflect.Constructor<AlbumUtils> constructor =
-              AlbumUtils.class.getDeclaredConstructor();
-          constructor.setAccessible(true);
-          try {
-            constructor.newInstance();
-          } catch (java.lang.reflect.InvocationTargetException e) {
-            throw (IllegalStateException) e.getCause();
-          }
-        });
+    assertThrows(BusinessException.class, () -> AlbumUtils.formatYear(date));
   }
 }


### PR DESCRIPTION

This pull request adds unit tests for the `AlbumUtils` class. 

1.Added test for `formatYear` method:
   - Tests the `formatYear` method with a valid date string.
   - Tests the `formatYear` method with an invalid date string and expects a `StringIndexOutOfBoundsException`.

2.Added test for private constructor:
   - Uses reflection to access the private constructor of the `AlbumUtils` class.
   - Ensures that the private constructor throws an `IllegalStateException`.