### PR TITLE
Add unit tests for ApplicationState

### DIFF
--- a/src/test/java/com/josdem/jmetadata/util/ApplicationStateTest.java
+++ b/src/test/java/com/josdem/jmetadata/util/ApplicationStateTest.java
@@ -13,12 +13,12 @@ class ApplicationStateTest {
   @DisplayName("adding and retrieving from cache")
   void testAddAndRetrieveFromCache() {
     // Arrange
-    String key = "testKey";
+    var key = "testKey";
     MusicBrainzResponse response = new MusicBrainzResponse();
     ApplicationState.cache.put(key, response);
 
     // Act
-    MusicBrainzResponse cachedResponse = ApplicationState.cache.get(key);
+    var cachedResponse = ApplicationState.cache.get(key);
 
     // Assert
     assertEquals(response, cachedResponse);
@@ -28,10 +28,10 @@ class ApplicationStateTest {
   @DisplayName("retrieving non-existent key from cache")
   void testRetrieveNonExistentKeyFromCache() {
     // Arrange
-    String key = "nonExistentKey";
+    var key = "nonExistentKey";
 
     // Act
-    MusicBrainzResponse cachedResponse = ApplicationState.cache.get(key);
+    var cachedResponse = ApplicationState.cache.get(key);
 
     // Assert
     assertNull(cachedResponse);
@@ -41,13 +41,13 @@ class ApplicationStateTest {
   @DisplayName("removing from cache")
   void testRemoveFromCache() {
     // Arrange
-    String key = "testKey";
+    var key = "testKey";
     MusicBrainzResponse response = new MusicBrainzResponse();
     ApplicationState.cache.put(key, response);
 
     // Act
     ApplicationState.cache.remove(key);
-    MusicBrainzResponse cachedResponse = ApplicationState.cache.get(key);
+    var cachedResponse = ApplicationState.cache.get(key);
 
     // Assert
     assertNull(cachedResponse);

--- a/src/test/java/com/josdem/jmetadata/util/ApplicationStateTest.java
+++ b/src/test/java/com/josdem/jmetadata/util/ApplicationStateTest.java
@@ -6,13 +6,12 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import com.josdem.jmetadata.model.MusicBrainzResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 
-public class ApplicationStateTest {
+class ApplicationStateTest {
 
   @Test
   @DisplayName("adding and retrieving from cache")
-  public void testAddAndRetrieveFromCache(TestInfo testInfo) {
+  void testAddAndRetrieveFromCache() {
     // Arrange
     String key = "testKey";
     MusicBrainzResponse response = new MusicBrainzResponse();
@@ -27,7 +26,7 @@ public class ApplicationStateTest {
 
   @Test
   @DisplayName("retrieving non-existent key from cache")
-  public void testRetrieveNonExistentKeyFromCache(TestInfo testInfo) {
+  void testRetrieveNonExistentKeyFromCache() {
     // Arrange
     String key = "nonExistentKey";
 
@@ -40,7 +39,7 @@ public class ApplicationStateTest {
 
   @Test
   @DisplayName("removing from cache")
-  public void testRemoveFromCache(TestInfo testInfo) {
+  void testRemoveFromCache() {
     // Arrange
     String key = "testKey";
     MusicBrainzResponse response = new MusicBrainzResponse();

--- a/src/test/java/com/josdem/jmetadata/util/ApplicationStateTest.java
+++ b/src/test/java/com/josdem/jmetadata/util/ApplicationStateTest.java
@@ -3,18 +3,26 @@ package com.josdem.jmetadata.util;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import org.junit.jupiter.api.BeforeEach;
+
 import com.josdem.jmetadata.model.MusicBrainzResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class ApplicationStateTest {
 
+  private MusicBrainzResponse response;
+
+  @BeforeEach
+  public void setUp() {
+    response = new MusicBrainzResponse();
+  }
+
   @Test
   @DisplayName("adding and retrieving from cache")
   void testAddAndRetrieveFromCache() {
     // Arrange
     var key = "testKey";
-    MusicBrainzResponse response = new MusicBrainzResponse();
     ApplicationState.cache.put(key, response);
 
     // Act
@@ -42,7 +50,6 @@ class ApplicationStateTest {
   void testRemoveFromCache() {
     // Arrange
     var key = "testKey";
-    MusicBrainzResponse response = new MusicBrainzResponse();
     ApplicationState.cache.put(key, response);
 
     // Act

--- a/src/test/java/com/josdem/jmetadata/util/ApplicationStateTest.java
+++ b/src/test/java/com/josdem/jmetadata/util/ApplicationStateTest.java
@@ -1,0 +1,56 @@
+package com.josdem.jmetadata.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.josdem.jmetadata.model.MusicBrainzResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+public class ApplicationStateTest {
+
+  @Test
+  @DisplayName("adding and retrieving from cache")
+  public void testAddAndRetrieveFromCache(TestInfo testInfo) {
+    // Arrange
+    String key = "testKey";
+    MusicBrainzResponse response = new MusicBrainzResponse();
+    ApplicationState.cache.put(key, response);
+
+    // Act
+    MusicBrainzResponse cachedResponse = ApplicationState.cache.get(key);
+
+    // Assert
+    assertEquals(response, cachedResponse);
+  }
+
+  @Test
+  @DisplayName("retrieving non-existent key from cache")
+  public void testRetrieveNonExistentKeyFromCache(TestInfo testInfo) {
+    // Arrange
+    String key = "nonExistentKey";
+
+    // Act
+    MusicBrainzResponse cachedResponse = ApplicationState.cache.get(key);
+
+    // Assert
+    assertNull(cachedResponse);
+  }
+
+  @Test
+  @DisplayName("removing from cache")
+  public void testRemoveFromCache(TestInfo testInfo) {
+    // Arrange
+    String key = "testKey";
+    MusicBrainzResponse response = new MusicBrainzResponse();
+    ApplicationState.cache.put(key, response);
+
+    // Act
+    ApplicationState.cache.remove(key);
+    MusicBrainzResponse cachedResponse = ApplicationState.cache.get(key);
+
+    // Assert
+    assertNull(cachedResponse);
+  }
+}


### PR DESCRIPTION
The following tests were added:

1.Adding and Retrieving from Cache:
   - Adds an entry to the cache and retrieves it to ensure it was added correctly.

2.Retrieving Non-Existent Key from Cache:
   - Attempts to retrieve a non-existent key from the cache and ensures the result is `null`.

3.Removing from Cache:
   - Adds an entry to the cache, removes it, and ensures it was removed correctly.