### PR TITLE
Add unit tests for`Environment.java`

### DIFF
--- a/src/test/java/com/josdem/jmetadata/util/EnvironmentTest.java
+++ b/src/test/java/com/josdem/jmetadata/util/EnvironmentTest.java
@@ -1,0 +1,47 @@
+package com.josdem.jmetadata.util;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+
+class EnvironmentTest {
+
+    private String originalOsName;
+
+    @BeforeEach
+    void setUp() {
+        originalOsName = System.getProperty("os.name");
+    }
+
+    @AfterEach
+    void tearDown() {
+        System.setProperty("os.name", originalOsName);
+    }
+
+    @Test
+    void testIsLinuxWhenLinux() {
+        System.setProperty("os.name", "Linux");
+        assertTrue(Environment.isLinux(), "Expected isLinux to return true for Linux OS");
+    }
+
+    @Test
+    void testIsLinuxWhenNotLinux() {
+        System.setProperty("os.name", "Windows 10");
+        assertFalse(Environment.isLinux(), "Expected isLinux to return false for non-Linux OS");
+    }
+
+    @Test
+    void testIsLinuxWhenMac() {
+        System.setProperty("os.name", "Mac OS X");
+        assertFalse(Environment.isLinux(), "Expected isLinux to return false for Mac OS");
+    }
+
+    @Test
+    void testIsLinuxWhenLinuxCaseInsensitive() {
+        System.setProperty("os.name", "LiNuX");
+        assertTrue(Environment.isLinux(), "Expected isLinux to return true for mixed-case Linux OS");
+    }
+}


### PR DESCRIPTION
Tests:
    testIsLinuxWhenLinux: Sets os.name to "Linux" and asserts that isLinux returns true.
    testIsLinuxWhenNotLinux: Sets os.name to "Windows 10" and asserts that isLinux returns false.
    testIsLinuxWhenMac: Sets os.name to "Mac OS X" and asserts that isLinux returns false.
    testIsLinuxWhenLinuxCaseInsensitive: Sets os.name to a mixed-case "LiNuX" and asserts that isLinux returns true.
